### PR TITLE
Transfer logger correctly when weaver.* exists.

### DIFF
--- a/lib/Dist/Zilla/Plugin/PodWeaver.pm
+++ b/lib/Dist/Zilla/Plugin/PodWeaver.pm
@@ -74,7 +74,7 @@ sub weaver {
   } elsif (@files) {
     return Pod::Weaver->new_from_config(
       { root   => $self->zilla->root },
-      { logger => $self->logger },
+      { root_config => { logger => $self->logger } },
     );
   } else {
     return Pod::Weaver->new_with_default_config($arg);


### PR DESCRIPTION
This can be considered as reopen of [rt.cpan.org#80684](https://rt.cpan.org/Ticket/Display.html?id=80684)
It is necessary to wrap root_config to pass logger correctly.
